### PR TITLE
chore: updating to run node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
     default: "updated"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"
 branding:
   icon: "git-pull-request"


### PR DESCRIPTION
Node 12 actions are deprecated.

@danilo-delbusso pretty straightforward update here to eliminate the deprecation warnings.